### PR TITLE
Fix ssr with css module

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = function(webpackEnv, executionEnv) {
       isEnvDevelopment &&
         (isEnvWeb
           ? require.resolve('style-loader')
-          : require.resolve('null-loader')),
+          : require.resolve('isomorphic-style-loader')),
       isEnvProduction && {
         loader: MiniCssExtractPlugin.loader,
         options: shouldUseRelativeAssetPaths ? { publicPath: '../../' } : {},

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -63,7 +63,7 @@
     "jest-resolve": "24.7.1",
     "jest-watch-typeahead": "0.3.0",
     "mini-css-extract-plugin": "0.5.0",
-    "null-loader": "0.1.1",
+    "isomorphic-style-loader": "^5.1.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.2.1",
     "postcss-flexbugs-fixes": "4.1.0",


### PR DESCRIPTION
This PR fixed react-scripts cannot be used with CSS modules, that null-loader makes it impossible to load css code to generate css modules